### PR TITLE
Ch/add fp ept

### DIFF
--- a/config/config_trne.yaml
+++ b/config/config_trne.yaml
@@ -2,11 +2,12 @@
 prepare_data.py:  
   srs: EPSG:2056
   datasets:
-    shapefile: ./data/ground_truth/20240805_GT.gpkg             # GT labels
+    shapefile: ./data/ground_truth/20240916_GT_MT_MES.gpkg         # GT labels
     # FP_shapefile: ./data/FP/FP_list.gpkg                        # FP labels
     # empty_tiles_aoi: ./data/AoI/AoI_2020.shp                    # AOI in which additional empty tiles can be selected. Only one 'empty_tiles' option can be selected  
-    empty_tiles_shp: ./data/EPT/20240726_EPT.gpkg             # Provided shpfile of selected empty tiles. Only one 'empty_tiles' option can be selected                     
-    category: 'Classe'
+    # empty_tiles_year: multi-year                                # If "empty_tiles_aoi" selected then provide a year. Choice: (1) numeric (i.e. 2020), (2) multi-year (random year selection within years [1945-2023]) 
+    # empty_tiles_shp: ./data/EPT/20240726_EPT.gpkg             # Provided shpfile of selected empty tiles. Only one 'empty_tiles' option can be selected                     
+    # category: 'Classe'
   output_folder: ./output/OD/trne/
   zoom_level: 16 
 


### PR DESCRIPTION
This branch enables adding empty tiles by randomly selecting tiles in an AoI or by providing a shapefile of selected tiles. It allows as well the addition of FP detections to the training dataset. 
It works along with the branch `ch/add_FP_EPT` of the `object-detector` https://github.com/swiss-territorial-data-lab/object-detector/pull/32
All the input data are available on S3/proj-sda/data.